### PR TITLE
New syntax for the orbs stanza in config

### DIFF
--- a/docs/inline-orbs.md
+++ b/docs/inline-orbs.md
@@ -19,7 +19,7 @@ orbs:
       myjob:
         executor: default
         steps:
-          - dospcialthings
+          - dospecialthings
 
 workflows:
   main:
@@ -28,11 +28,4 @@ workflows:
 
 In the above sample the contents of `my-orb` are resolved as an inline orb because the contents of `my-orb` are a map. Whereas the contents of `ror` are scalar value and thus assumed to be an orb URI.
 
-## Publishing inline orbs to the registry
-
-To publish an inline orb to the registry you can use the CLI to extract it and push it to the registry:
-
-`circleci orb publish --from-inline path/to/orb.yml --namespace mycompany --name myspecialorb --version 1.1.1`
-
-Note that you can also directly publish through our GraphQL API, though the CLI encapsulates that funcionality and is the recommended method.
 

--- a/docs/inline-orbs.md
+++ b/docs/inline-orbs.md
@@ -1,0 +1,38 @@
+# Writing Inline Orbs
+Inline orbs can be handy during development of an orb or as a convenience for namespacing jobs and commands in lengthy configurations, particularly if you later intend to share the orb.
+
+To write inline orbs you would put the orb elements under that orb's key in the `orbs` declaration in config. For instance, if I wanted to import one orb then author inline for another it might look like:
+
+```
+orbs:
+  ror: circleci/rails@latest
+  my-orb:
+    executors:
+      default:
+        docker:
+          - image: circleci/ruby:1.4.2
+    commands:
+      dospecialthings:
+        steps:
+          - run: echo: "We will now do special things
+    jobs:
+      myjob:
+        executor: default
+        steps:
+          - dospcialthings
+
+workflows:
+  main:
+    - my-orb/myjob
+```
+
+In the above sample the contents of `my-orb` are resolved as an inline orb because the contents of `my-orb` are a map. Whereas the contents of `ror` are scalar value and thus assumed to be an orb URI.
+
+## Publishing inline orbs to the registry
+
+To publish an inline orb to the registry you can use the CLI to extract it and push it to the registry:
+
+`circleci orb publish --from-inline path/to/orb.yml --namespace mycompany --name myspecialorb --version 1.1.1`
+
+Note that you can also directly publish through our GraphQL API, though the CLI encapsulates that funcionality and is the recommended method.
+

--- a/docs/using-orbs.md
+++ b/docs/using-orbs.md
@@ -1,0 +1,39 @@
+# Using Orbs in CirlceCI Configuration
+
+Orbs are packages of CircleCI configuration shared across projects. Orbs are made available for use in configuration through the `orbs` key in the top level of your config.yml. 
+
+Importing a set of orbs might look like:
+
+```
+orbs:
+  rails: circleci/rails@1.13.3
+  python: circleci/python@2.1
+  heroku: circleci/heroku@latest
+```
+
+The above would make three orbs available, one for each key in the map and named the same as the keys in the map. 
+
+You can also write [inline orbs](inline-orbs), which can be especially useful during development of a new orb. Because the values of the above keys under `orbs` are all scalar values they are assumed to imports based on the orb URI format.
+
+## Orb URI Format
+Orb URIs have the format:
+
+`[namespace]/[orb]@[version]`
+
+Orb namespaces may have restrictions that prevent you from accesing orbs in those namespaces based on whether the build and the scope of the namespace are congruent.
+
+## Semantic Versioning in Orbs
+
+Orbs are published with the standard 3-number [semantic versioning system](https://semver.org/), `major.minor.patch`, and orb authors need to adhere to semantic versioning. Within `config.yml`, you can specify wildcard version ranges to resovle orbs. You can also use the special string `latest` to pull in whatever the highest version number is.  
+
+For instance, the versions below have the following meaning:
+
+1. `circleci/python@latest` - use the latest version of the Python orb in the registry at the time a build is triggered.
+2. `circleci/python@2.*.*` - use the latest version of version 2.x.x of the Python orb .
+3. `circleci/python@2.4.*` - use the latest version of version 2.4.x of the Python orb .
+4. `circleci/python@3.1.4` - use exactly version 3.1.4 of the Python orb.
+
+
+
+
+ 


### PR DESCRIPTION
This PR has a speculative approach to the `orbs` stanza to unify inline orb development with orb importing, making them the same structure.  