### PR TITLE
Syntax-highlight YAML &  Fix YAML syntax

### DIFF
--- a/docs/conditional-steps.md
+++ b/docs/conditional-steps.md
@@ -20,7 +20,7 @@ A conditional step consists of a step with the key `when` or `unless`. Under thi
 
 ### Example
 
-```
+```yaml
 # Contents of the orb `myorb` in namespace `mynamespace`
 jobs:
   myjob:
@@ -41,7 +41,7 @@ jobs:
             - run: echo "don't preinstall"
 ```
 
-```
+```yaml
 # inside config.yml
 version: 2
 

--- a/docs/design-approach.md
+++ b/docs/design-approach.md
@@ -49,7 +49,7 @@ We choose to enforce a strict format for [semver](https://semver.org/) on all pu
 1. **Register-time Dependency Resolution:** If an orb (`my-orb`) imports other orbs, we will resolve and lock those dependencies at the time that `my-orb` is added to the registry.
 For instance, let's say that you publish version 1.2.0 of `my-orb`, and it contains:
 
-```
+```yaml
 orbs:
   foo-orb: somenamespace/some-orb:volatile` 
 ```

--- a/docs/executors.md
+++ b/docs/executors.md
@@ -20,7 +20,7 @@ An executor definition includes the subset of the children keys of a `job` decla
 
 A simple example of using an executor:
 
-```
+```yaml
 version: 2
 executors:
   my-executor:
@@ -36,7 +36,7 @@ jobs:
 
 In the above example the executor `my-executor` is passed as the single value of the key `executor`. Alternatively, you can pass `my-executor` as the value of a `name` key under `executor` -- this method is primarily employed when passing parameters to executor invocations (see below):
 
-```
+```yaml
 jobs:
   my-job:
     executor:
@@ -61,7 +61,7 @@ Imagine you have several jobs that you need to run in the same Docker image and 
 With an executor declaration your configuration might look something like: 
 
 **Without executors**
-```
+```yaml
 jobs:
   build:
     docker:
@@ -87,7 +87,7 @@ jobs:
 ```
     
 **Same Code, With executors**
-```
+```yaml
 executors:
   lein_exec:
     docker:
@@ -155,7 +155,7 @@ When invoking an executor in a `job` any keys in the job itself will override th
 
 There is **one exception** to this rule: `environment` variable maps are additive. If an `executor` has one of the same `environment` variables as the `job`, the `job`'s value will win. For example, if you had the following configuration:
 
-```
+```yaml
 executors:
   python:
     docker:
@@ -180,7 +180,7 @@ jobs:
 
 
 This would resolve to:
-```
+```yaml
 jobs:
  build:
    steps: []
@@ -200,7 +200,7 @@ If you'd like to use parameters in executors, define the parameters under the gi
 Parameters in executors can be of the type `string` or `boolean`. Default values can be provided with the optional `default` key.
 
 **Example build configuration using a parameterized executor**
-```
+```yaml
 version: 2
 
 executors:
@@ -225,7 +225,7 @@ jobs:
 ```
 
 **The above would resolve to:**
-```
+```yaml
 version: 2
 jobs:
   build:

--- a/docs/inline-orbs.md
+++ b/docs/inline-orbs.md
@@ -5,7 +5,7 @@ Inline orbs can be handy during development of an orb or as a convenience for na
 
 To write inline orbs you would put the orb elements under that orb's key in the `orbs` declaration in config. For instance, if I wanted to import one orb then author inline for another it might look like:
 
-```
+```yaml
 orbs:
   ror: circleci/rails@volatile
   my-orb:

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -33,7 +33,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - sayhello
+      - sayhello:
           saywhat: Everyone
 ```
 
@@ -111,7 +111,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - sayhello
+      - sayhello:
           saywhat: Everyone
 ```
 

--- a/docs/pre-and-post-steps.md
+++ b/docs/pre-and-post-steps.md
@@ -23,7 +23,7 @@ but it requires that the job be modified with an execution site for the paramete
 
 An orb `foo` might define a job:
 
-```
+```yaml
 # yaml from orb `foo`
 jobs:
   bar:
@@ -37,7 +37,7 @@ jobs:
 ```
 
 Then an orb user could use the job as follows:
-```
+```yaml
 # config.yml
 version: 2
 orbs:
@@ -57,7 +57,7 @@ workflows:
 
 The resulting configuration would look like this:
 
-```
+```yaml
 version: 2
 jobs:
   foo/bar:

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -10,7 +10,7 @@ Orbs are composed of one or more of the following elements, each of which repres
 * [executors](executors.md)
 
 An example orb:
-```
+```yaml
 # foo Orb
 commands:
   echo:

--- a/docs/using-orbs.md
+++ b/docs/using-orbs.md
@@ -5,7 +5,7 @@ Orbs are packages of CircleCI configuration shared across projects. Orbs are mad
 
 Importing a set of orbs might look like:
 
-```
+```yaml
 orbs:
   rails: circleci/rails@1.13.3
   python: circleci/python@2.1


### PR DESCRIPTION
Thank you for great features!

While trying out new configurations, I found two YAML syntax errors (69a3020), which gave me a hard time debugging.

Also, there were few places YAML codes are not syntax-highlighted.