### PR TITLE
Make capitalization more consistent in the docs.

### DIFF
--- a/docs/executors.md
+++ b/docs/executors.md
@@ -1,4 +1,4 @@
-# Authoring and using Executors 
+# Authoring and using executors 
 _Reusable `executor` declarations are available in configuration version 2.1 and later_
 
 - [What _is_ an executor?](#what-is-an-executor)

--- a/docs/inline-orbs.md
+++ b/docs/inline-orbs.md
@@ -1,4 +1,4 @@
-# Writing Inline Orbs
+# Writing inline orbs
 _The `orbs` stanza is available in configuration version 2.1 and later_
 
 Inline orbs can be handy during development of an orb or as a convenience for namespacing jobs and commands in lengthy configurations, particularly if you later intend to share the orb.

--- a/docs/orbs-authoring.md
+++ b/docs/orbs-authoring.md
@@ -1,4 +1,4 @@
-# Authoring and Publishing Orbs
+# Authoring and publishing orbs
 This document largely covers the tooling and flow of authoring and publishing your own orbs to the orb registry. Check out the [documentation on using orbs](using-orbs.md) for more information on how to pull orbs into your build configuration.
 
 Orbs can be authored [inline](inline-orbs.md) in your config.yml file or authored separately and then published to to the orb registry for reuse across projects. This document is largely about how to publish orbs for use across projects. For inline orbs see the [Writing Inline Orbs](inline-orbs.md) document.
@@ -6,9 +6,9 @@ Orbs can be authored [inline](inline-orbs.md) in your config.yml file or authore
 ## Prerequisites
 To start orb publishing you will need to opt-in to the new 3rd Party Software terms and turn on orb publishing for your organization. Only an organization admin can do this from the Settings page on your organization inside CircleCI. Under Settings look for the Security tab where you will find the form for opting in.
 
-## Concepts in Orb Publishing
+## Concepts in orb publishing
 
-### Orb Registry
+### Orb registry
 Each installation of CircleCI has a single orb registry. The registry on circleci.com serves as the master source for all certified namespaces and orbs and is the only orb registry users of circleci.com can use.
 
 When orb features come to the server installation of CircleCI, each installation will have its own registry that operators can control. NOTE: as of September 2018 the orb features are not yet supported on server installations (TODO: update this doc if orbs are now on server installs).
@@ -20,7 +20,7 @@ Namespaces are owned by organizations. Only organization administrators can crea
 
 Organizations are, by default, limited to claiming only one namespace. This policy is designed to limit name squatting and namespace noise. If you require more than one namespace please contact your account team at CircleCI.
 
-### Dev vs. Production Orbs
+### Dev vs. production orbs
 Versions of orbs can be added to the registry either as development versions or production versions. Production versions are always a semver like `1.5.3`, and development versions can be tagged with a string and are always prefixed with `dev:`.
 
 #### Dev and production orbs have different security profiles:

--- a/docs/packing-config-files-into-one.md
+++ b/docs/packing-config-files-into-one.md
@@ -1,4 +1,4 @@
-# Packing Config Files
+# Packing config files
 
 `circleci config pack` converts a filesystem tree into a single yaml file
 based on directory structure and file contents. It prints the merged contents

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,4 +1,4 @@
-# Using Parameters in CircleCI Configuration Elements
+# Using parameters in CircleCI configuration elements
 _The `parameters` declaration is available in configuration version 2.1 and later._
 
 Many config elements can be authored to be invocable in your `config.yml` file with specified parameters. Parameters are declared by name as the keys in a map that are all immediate children of the `parameters` key under a job, command, or executor. 
@@ -39,7 +39,7 @@ A parameter can have the following keys as immediate children:
 | type        | Required. Currently "string", "boolean", "enum", and "steps" are supported                           | N/A           |
 | default     | The default value for the parameter. If not present, the parameter is implied to be required. | N/A           |
 
-## Parameter Types
+## Parameter types
 
 This section describes the 
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,8 +1,8 @@
 # Orb structure
 
-Each Orb is packaged as a single file. Each Orb also has its own namespace to use when invoking its elements. Orbs are authored with similar YAML syntax to the base CircleCI build configuration.
+Each orb is packaged as a single file. Each orb also has its own namespace to use when invoking its elements. Orbs are authored with similar YAML syntax to the base CircleCI build configuration.
 
-## Anatomy of an Orb
+## Anatomy of an orb
 Orbs are composed of one or more of the following elements, each of which represents a type of invocable element in CircleCI project configuration:
 
 * [commands](commands.md)
@@ -11,7 +11,7 @@ Orbs are composed of one or more of the following elements, each of which repres
 
 An example orb:
 ```yaml
-# foo Orb
+# foo orb
 commands:
   echo:
     steps:
@@ -29,7 +29,7 @@ Our sample orb above has a single command name `echo` and a single job named `he
 
 Orb, command, job, executor, and parameter names can only contain lowercase letters a-z, digits, and _ and -, and must start with a letter.
 
-### Scoping considerations in Orb invocation
+### Scoping considerations in orb invocation
 
 An orb `foo` effectively has a namespace called `foo` for use in your build configuration, and everything directly inside an orb is considered local to that orb.
 

--- a/docs/using-orbs.md
+++ b/docs/using-orbs.md
@@ -1,4 +1,4 @@
-# Using Orbs in CircleCI Configuration
+# Using orbs in CircleCI configuration
 _The `orbs` stanza is available in configuration version 2.1 and later._
 
 Orbs are packages of CircleCI configuration shared across projects. Orbs are made available for use in configuration through the `orbs` key in the top level of your config.yml.
@@ -18,19 +18,19 @@ The above would make three orbs available, one for each key in the map and named
 
 You can also write [inline orbs](inline-orbs.md), which can be especially useful during development of a new orb. Because the values of the above keys under `orbs` are all scalar values they are assumed to imports based on the orb URI format.
 
-## Certified Orbs vs. 3rd Party Orbs
+## Certified orbs vs. 3rd party orbs
 Certified orbs are those that CircleCI has built or has reviewed and approved as part of the features of the CircleCI platform. Any project may use certified orbs in configuration version 2.1 and higher. 
 
 3rd party orbs are those published by our customers and other members of our community. For you to publish orbs or for your projects to use 3rd party orbs, your organization must opt-in under SECURITY within the Organization Settings page under the section "Orb Security Settings" where an organization administrator must agree to the terms for using 3rd party software (NOTE: if you do not yet see this feature under your organization settings you should in the next few weeks as we roll it out gradually). This setting can only be toggled by organization administrators.
 
-## Orb URI Format
+## Orb URI format
 Orb URIs have the format:
 
 `[namespace]/[orb]@[version]`
 
 Orb namespaces may have restrictions that prevent you from accessing orbs in those namespaces based on whether the build and the scope of the namespace are congruent.
 
-## Semantic Versioning in Orbs
+## Semantic versioning in orbs
 Orbs are published with the standard 3-number [semantic versioning system](https://semver.org/), `major.minor.patch`, and orb authors need to adhere to semantic versioning. Within `config.yml`, you can specify wildcard version ranges to resolve orbs. You can also use the special string `volatile` to pull in whatever the highest version number is at time your build runs. For instance, when `mynamespace/some-orb@8.2.0` exists, and `mynamespace/some-orb@8.1.24` and `mynamespace/some-orb@8.0.56` are published after `8.2.0`, volatile will still refer to `mynamespace/some-orb@8.2.0` as the highest semver.
 
 Examples of orb version declarations and their meaning:
@@ -41,7 +41,7 @@ Examples of orb version declarations and their meaning:
 4. `circleci/python@3.1.4` - use exactly version 3.1.4 of the Python orb.
 
 ### Using dev versions
-While all production orbs must be published securely by organization admins, dev orbs allow your team broader lattitude. See the [Orb Authoring and Publishing doc](orbs-authoring.md) for details of how to create your own dev orbs. 
+While all production orbs must be published securely by organization admins, dev orbs allow your team broader lattitude. See the [Orb authoring and publishing doc](orbs-authoring.md) for details of how to create your own dev orbs.
 
 A dev version must be referenced entirely, like `mynamespace/myorb@dev:mybranch`. Whereas production orbs allow wildcard semver references, there are no shorthand conveniences for dev versions. 
 


### PR DESCRIPTION
My main motivation for these changes was making sure we don't capitalize "Orb", but that led me to some headline fix-ups as well.